### PR TITLE
Accept 415 status code for marketing site monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -10,6 +10,9 @@ sites:
     url: https://app.joinyearone.io
   - name: YearOne Marketing Website
     url: https://joinyearone.io
+    expectedStatusCodes:
+      - 200
+      - 415
   - name: YearOne Sidekiq Queues
     url: https://app.joinyearone.io/health/sidekiq
     expectedStatusCodes:


### PR DESCRIPTION
## Summary
- Configure Upptime to accept HTTP 415 status codes as valid for the YearOne Marketing Website
- Prevents false positive alerts when the marketing site returns 415 responses

## Test plan
- [ ] Verify the Upptime configuration accepts 415 status codes
- [ ] Confirm no false alerts are triggered for 415 responses from joinyearone.io
- [ ] Check that other status codes still trigger alerts appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)